### PR TITLE
[AUTO-1135] datadog logging and apm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ defaults/main.yml and vars/main.yml contain variables. Please change the sonar_p
 Dependencies
 ------------
 
-You can run this role combined with the role pcextreme.mariadb. An implementation with Postgres is possible.
+- You can run this role combined with the role pcextreme.mariadb. An implementation with Postgres is possible.
+- This role assumes the vanilla datadog-agent was already configured, if it hasn't been please do not run the tasks tagged `datadog`.
 
 Example Usage
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,23 +23,23 @@ sonar_file: "{{ sonar_name }}.zip"
 sonar_url: 'https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/{{ sonar_file }}'
 sonar_home: /opt/sonar
 sonar_directory: "{{ sonar_home }}/sonarqube-{{ sonar_version }}"
-dd_jvm_opts:
-  - "-Ddd.service.name={{ sonar_name }}"
-  - "-Ddd.trace.analytics.enabled=true"
-  - "-Ddd.trace.report-hostname=true"
-  - "-Ddd.jmxfetch.jetty.enabled=true"
-  - "-Ddd.trace.global.tags=env:management,application:{{ sonar_name }},service:{{ sonar_name }}"
-  - "-Ddd.http.client.tag.query-string=true"
-  - "-Ddd.http.server.tag.query-string=true"
+dd_jvm_opts: >
+  -Ddd.trace.report-hostname=true
+  -Ddd.jmxfetch.jetty.enabled=true
+  -Ddd.trace.global.tags=env:management,application:{{ sonar_name }},service:{{ sonar_name }} -Ddd.http.client.tag.query-string=true
+  -Ddd.http.server.tag.query-string=true
+  -Ddd.logs.injection=true
+  -Ddd.service.name={{ sonar_name }}
+  -Ddd.trace.analytics.enabled=true
 
-sonar_web_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+sonar_web_javaopts: "-javaagent:/etc/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 sonar_web_javaadditionalopts: "{{ dd_jvm_opts }}"
 
-sonar_search_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar"
-sonar_search_javaadditionalopts: "{{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
+sonar_search_javaopts: false
+sonar_search_javaadditionalopts: "-Dbootstrap.system_call_filter=false"
 
-sonar_ce_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar"
-sonar_ce_javaadditionalopts: "{{ dd_jvm_opts }}"
+sonar_ce_javaopts: false
+sonar_ce_javaadditionalopts: false
 
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ dd_jvm_opts: >
   -Ddd.trace.analytics.enabled=true
 
 
-sonar_web_javaopts: "-javaagent:/opt/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+sonar_web_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 sonar_web_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }} {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ dd_jvm_opts: >
   -Ddd.trace.analytics.enabled=true
 
 
-sonar_web_javaopts: "-javaagent:/etc/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+sonar_web_javaopts: "-javaagent:/opt/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
 sonar_web_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:web {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,13 +37,13 @@ dd_jvm_opts: >
 
 
 sonar_web_javaopts: "-javaagent:/opt/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
-sonar_web_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:web {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
+sonar_web_javaadditionalopts: " {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false
-sonar_search_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:es -Dbootstrap.system_call_filter=false"
+sonar_search_javaadditionalopts: "-Dbootstrap.system_call_filter=false"
 
 sonar_ce_javaopts: false
-sonar_ce_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:ce"
+sonar_ce_javaadditionalopts: false
 
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,22 +23,27 @@ sonar_file: "{{ sonar_name }}.zip"
 sonar_url: 'https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/{{ sonar_file }}'
 sonar_home: /opt/sonar
 sonar_directory: "{{ sonar_home }}/sonarqube-{{ sonar_version }}"
+
+# The service name won't register for sonarqube's database (postgresql and elasticsearch) that're in the instance. We cannot change their name in the reporting.
+dd_service_name: sonarqube-enterprise
+
 dd_jvm_opts: >
   -Ddd.trace.report-hostname=true
   -Ddd.jmxfetch.jetty.enabled=true
-  -Ddd.trace.global.tags=env:management,application:{{ sonar_name }},service:{{ sonar_name }} -Ddd.http.client.tag.query-string=true
+  -Ddd.trace.global.tags=env:management,application:{{ dd_service_name }},service:{{ dd_service_name }} -Ddd.http.client.tag.query-string=true
   -Ddd.http.server.tag.query-string=true
   -Ddd.logs.injection=true
   -Ddd.trace.analytics.enabled=true
 
+
 sonar_web_javaopts: "-javaagent:/etc/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
-sonar_web_javaadditionalopts: "-Ddd.service.name=web.{{ sonar_name }} {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
+sonar_web_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:web {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false
-sonar_search_javaadditionalopts: "-Ddd.service.name=es.{{ sonar_name }} -Dbootstrap.system_call_filter=false"
+sonar_search_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:es -Dbootstrap.system_call_filter=false"
 
 sonar_ce_javaopts: false
-sonar_ce_javaadditionalopts: "-Ddd.service.name=ce.{{ sonar_name }}"
+sonar_ce_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}:ce"
 
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,13 +37,13 @@ dd_jvm_opts: >
 
 
 sonar_web_javaopts: "-javaagent:/opt/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
-sonar_web_javaadditionalopts: " {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
+sonar_web_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }} {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false
-sonar_search_javaadditionalopts: "-Dbootstrap.system_call_filter=false"
+sonar_search_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }} -Dbootstrap.system_call_filter=false"
 
 sonar_ce_javaopts: false
-sonar_ce_javaadditionalopts: false
+sonar_ce_javaadditionalopts: "-Ddd.service.name={{ dd_service_name }}"
 
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,17 +29,16 @@ dd_jvm_opts: >
   -Ddd.trace.global.tags=env:management,application:{{ sonar_name }},service:{{ sonar_name }} -Ddd.http.client.tag.query-string=true
   -Ddd.http.server.tag.query-string=true
   -Ddd.logs.injection=true
-  -Ddd.service.name={{ sonar_name }}
   -Ddd.trace.analytics.enabled=true
 
 sonar_web_javaopts: "-javaagent:/etc/datadog-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
-sonar_web_javaadditionalopts: "{{ dd_jvm_opts }}"
+sonar_web_javaadditionalopts: "-Ddd.service.name=web.{{ sonar_name }} {{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
 
 sonar_search_javaopts: false
-sonar_search_javaadditionalopts: "-Dbootstrap.system_call_filter=false"
+sonar_search_javaadditionalopts: "-Ddd.service.name=es.{{ sonar_name }} -Dbootstrap.system_call_filter=false"
 
 sonar_ce_javaopts: false
-sonar_ce_javaadditionalopts: false
+sonar_ce_javaadditionalopts: "-Ddd.service.name=ce.{{ sonar_name }}"
 
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"
@@ -48,6 +47,7 @@ sonar_log_names:
   - web
   - sonar
   - ce
+  - es
 
 sonar_plugins:
 # Integration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,12 +23,31 @@ sonar_file: "{{ sonar_name }}.zip"
 sonar_url: 'https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/{{ sonar_file }}'
 sonar_home: /opt/sonar
 sonar_directory: "{{ sonar_home }}/sonarqube-{{ sonar_version }}"
-sonar_web_javaopts: "-Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
-sonar_web_javaadditionalopts: False
-sonar_search_javaadditionalopts: "-Dbootstrap.system_call_filter=false"
+dd_jvm_opts:
+  - "-Ddd.service.name={{ sonar_name }}"
+  - "-Ddd.trace.analytics.enabled=true"
+  - "-Ddd.trace.report-hostname=true"
+  - "-Ddd.jmxfetch.jetty.enabled=true"
+  - "-Ddd.trace.global.tags=env:management,application:{{ sonar_name }},service:{{ sonar_name }}"
+  - "-Ddd.http.client.tag.query-string=true"
+  - "-Ddd.http.server.tag.query-string=true"
+
+sonar_web_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar -Xmx1024m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
+sonar_web_javaadditionalopts: "{{ dd_jvm_opts }}"
+
+sonar_search_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar"
+sonar_search_javaadditionalopts: "{{ dd_jvm_opts }} -Dbootstrap.system_call_filter=false"
+
+sonar_ce_javaopts: "-javaagent:/opt/datadog-java-agent/dd-java-agent.jar"
+sonar_ce_javaadditionalopts: "{{ dd_jvm_opts }}"
+
 sonar_secret: ''
 sonar_log_rolling_policy: "time:yyyy-MM-dd"
 sonar_log_max_files: 7
+sonar_log_names:
+  - web
+  - sonar
+  - ce
 
 sonar_plugins:
 # Integration

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,7 @@
 - name: 'restart sonar'
   become: yes
   service: name=sonar state=restarted
+
+- name: 'restart datadog-agent'
+  become: yes
+  service: name=datadog-agent state=restarted

--- a/tasks/datadog.yml
+++ b/tasks/datadog.yml
@@ -24,7 +24,7 @@
 
 - name: Create Datadog APM directory
   file:
-    path: /opt/datadog-agent
+    path: /opt/datadog-java-agent
     state: directory
     owner: dd-agent
     group: dd-agent
@@ -34,7 +34,7 @@
 - name: Download Datadog APM agent
   get_url:
     url: https://repo.dfw.rtrdc.net/rtr/global/dd-java-agent-0.33.0.jar
-    dest: /opt/datadog-agent/dd-java-agent.jar
+    dest: /opt/datadog-java-agent/dd-java-agent.jar
     validate_certs: no
   notify: restart sonar
   tags:

--- a/tasks/datadog.yml
+++ b/tasks/datadog.yml
@@ -7,8 +7,6 @@
     owner: dd-agent
     group: dd-agent
   loop: "{{ sonar_log_names }}"
-  tags:
-    - datadog
 
 - name: Create Datadog log config files.
   template:
@@ -19,8 +17,6 @@
     group: dd-agent
   loop: "{{ sonar_log_names }}"
   notify: restart datadog-agent
-  tags:
-    - datadog
 
 - name: Create Datadog APM directory
   file:
@@ -28,8 +24,6 @@
     state: directory
     owner: dd-agent
     group: dd-agent
-  tags:
-    - datadog
 
 - name: Download Datadog APM agent
   get_url:
@@ -37,6 +31,4 @@
     dest: /opt/datadog-java-agent/dd-java-agent.jar
     validate_certs: no
   notify: restart sonar
-  tags:
-    - datadog
 

--- a/tasks/dd_apm_logs_config.yml
+++ b/tasks/dd_apm_logs_config.yml
@@ -1,22 +1,35 @@
 ---
-name: Create Datadog log config files.
+- name: Create Datadog logging directories
+  file:
+    path: "/etc/datadog-agent/conf.d/{{ item }}.d/"
+    state: directory
+    mode: 0755
+    owner: dd-agent
+    group: dd-agent
+  loop: "{{ sonar_log_names }}"
+  tags:
+    - sonar
+    - sonarconfig
+    - datadog
+
+- name: Create Datadog log config files.
   template:
     src: datadog-logs-config.yml
     dest: "/etc/datadog-agent/conf.d/{{ item }}.d/config.yaml"
+    mode: 0755
+    owner: dd-agent
+    group: dd-agent
   loop: "{{ sonar_log_names }}"
-  mode: 0400
-  owner: dd-agent
-  group: dd-agent
   notify: restart datadog-agent
   tags:
     - sonar
     - sonarconfig
     - datadog
 
-name: Download Datadog APM agent
+- name: Download Datadog APM agent
   get_url:
     url: https://repo.dfw.rtrdc.net/rtr/global/dd-java-agent-0.33.0.jar
-    dest: /opt/datadog-java-agent/dd-java-agent.jar
+    dest: /etc/datadog-agent/dd-java-agent.jar
     validate_certs: no
   notify: restart sonar
   tags:

--- a/tasks/dd_apm_logs_config.yml
+++ b/tasks/dd_apm_logs_config.yml
@@ -8,8 +8,6 @@
     group: dd-agent
   loop: "{{ sonar_log_names }}"
   tags:
-    - sonar
-    - sonarconfig
     - datadog
 
 - name: Create Datadog log config files.
@@ -22,8 +20,6 @@
   loop: "{{ sonar_log_names }}"
   notify: restart datadog-agent
   tags:
-    - sonar
-    - sonarconfig
     - datadog
 
 - name: Download Datadog APM agent
@@ -33,7 +29,5 @@
     validate_certs: no
   notify: restart sonar
   tags:
-    - sonar
-    - sonarconfig
     - datadog
 

--- a/tasks/dd_apm_logs_config.yml
+++ b/tasks/dd_apm_logs_config.yml
@@ -22,10 +22,19 @@
   tags:
     - datadog
 
+- name: Create Datadog APM directory
+  file:
+    path: /opt/datadog-agent
+    state: directory
+    owner: dd-agent
+    group: dd-agent
+  tags:
+    - datadog
+
 - name: Download Datadog APM agent
   get_url:
     url: https://repo.dfw.rtrdc.net/rtr/global/dd-java-agent-0.33.0.jar
-    dest: /etc/datadog-agent/dd-java-agent.jar
+    dest: /opt/datadog-agent/dd-java-agent.jar
     validate_certs: no
   notify: restart sonar
   tags:

--- a/tasks/dd_apm_logs_config.yml
+++ b/tasks/dd_apm_logs_config.yml
@@ -7,6 +7,7 @@ name: Create Datadog log config files.
   mode: 0400
   owner: dd-agent
   group: dd-agent
+  notify: restart datadog-agent
   tags:
     - sonar
     - sonarconfig
@@ -17,6 +18,7 @@ name: Download Datadog APM agent
     url: https://repo.dfw.rtrdc.net/rtr/global/dd-java-agent-0.33.0.jar
     dest: /opt/datadog-java-agent/dd-java-agent.jar
     validate_certs: no
+  notify: restart sonar
   tags:
     - sonar
     - sonarconfig

--- a/tasks/dd_apm_logs_config.yml
+++ b/tasks/dd_apm_logs_config.yml
@@ -1,0 +1,24 @@
+---
+name: Create Datadog log config files.
+  template:
+    src: datadog-logs-config.yml
+    dest: "/etc/datadog-agent/conf.d/{{ item }}.d/config.yaml"
+  loop: "{{ sonar_log_names }}"
+  mode: 0400
+  owner: dd-agent
+  group: dd-agent
+  tags:
+    - sonar
+    - sonarconfig
+    - datadog
+
+name: Download Datadog APM agent
+  get_url:
+    url: https://repo.dfw.rtrdc.net/rtr/global/dd-java-agent-0.33.0.jar
+    dest: /opt/datadog-java-agent/dd-java-agent.jar
+    validate_certs: no
+  tags:
+    - sonar
+    - sonarconfig
+    - datadog
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: dd_apm_logs_config.yml
+- include: datadog.yml
 - include: memory_config.yml
 - include: dependencies.yml
 - include: runner.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: datadog.yml
+  tags: datadog
 - include: memory_config.yml
 - include: dependencies.yml
 - include: runner.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include: dd_apm_logs_config.yml
 - include: memory_config.yml
 - include: dependencies.yml
 - include: runner.yml

--- a/templates/datadog-logs-config.yml
+++ b/templates/datadog-logs-config.yml
@@ -1,6 +1,6 @@
 ---
 logs:
   - type: file
-    path: "/opt/sonar/logs/{{ item }}.log"
+    path: "{{ sonar_directory }}/logs/{{ item }}.log"
     service: "{{ sonar_name }}"
-    source: "{{ sonar_name }}"
+    source: "{{ item }}.{{ sonar_name }}"

--- a/templates/datadog-logs-config.yml
+++ b/templates/datadog-logs-config.yml
@@ -2,5 +2,5 @@
 logs:
   - type: file
     path: "{{ sonar_directory }}/logs/{{ item }}.log"
-    service: "{{ sonar_name }}"
-    source: "{{ item }}.{{ sonar_name }}"
+    service: "{{ dd_service_name }}"
+    source: "{{ dd_service_name }}:{{ item }}"

--- a/templates/datadog-logs-config.yml
+++ b/templates/datadog-logs-config.yml
@@ -1,0 +1,6 @@
+---
+logs:
+  - type: file
+    path: "/opt/sonar/logs/{{ item }}.log"
+    service: "{{ sonar_name }}"
+    source: "{{ sonar_name }}"

--- a/templates/sonar.properties
+++ b/templates/sonar.properties
@@ -249,13 +249,6 @@ sonar.web.javaAdditionalOpts={{ sonar_web_javaadditionalopts }}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 #sonar.ce.javaAdditionalOpts=
 
-{% if sonar_ce_javaopts %}
-sonar.ce.javaOpts={{ sonar_ce_javaopts }}
-{% endif %}
-{% if sonar_ce_javaadditionalopts %}
-# Same as previous property, but allows to not repeat all other settings like -Xmx
-sonar.ce.javaAdditionalOpts={{ sonar_ce_javaadditionalopts }}
-{% endif %}
 
 
 #--------------------------------------------------------------------------------------------------
@@ -276,10 +269,7 @@ sonar.ce.javaAdditionalOpts={{ sonar_ce_javaadditionalopts }}
 
 # JVM options of Elasticsearch process
 #sonar.search.javaOpts=-Xms2G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError
-
-{% if sonar_search_javaopts %}
-sonar.search.javaOpts={{ sonar_search_javaopts }}
-{% endif %}
+#sonar.search.javaOpts=-Xms2G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError
 {% if sonar_search_javaadditionalopts %}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 sonar.search.javaAdditionalOpts={{ sonar_search_javaadditionalopts }}

--- a/templates/sonar.properties
+++ b/templates/sonar.properties
@@ -245,10 +245,16 @@ sonar.web.javaAdditionalOpts={{ sonar_web_javaadditionalopts }}
 #    http://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html
 #
 #sonar.ce.javaOpts=-Xmx2G -Xms128m -XX:+HeapDumpOnOutOfMemoryError
-
+{% if sonar_ce_javaopts %}
+# Same as previous property, but allows to not repeat all other settings like -Xmx
+sonar.ce.javaOpts={{ sonar_ce_javaopts }}
+{% endif %}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 #sonar.ce.javaAdditionalOpts=
-
+{% if sonar_ce_javaadditionalopts %}
+# Same as previous property, but allows to not repeat all other settings like -Xmx
+sonar.ce.javaAdditionalOpts={{ sonar_ce_javaadditionalopts }}
+{% endif %}
 
 
 #--------------------------------------------------------------------------------------------------
@@ -269,7 +275,10 @@ sonar.web.javaAdditionalOpts={{ sonar_web_javaadditionalopts }}
 
 # JVM options of Elasticsearch process
 #sonar.search.javaOpts=-Xms2G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError
-#sonar.search.javaOpts=-Xms2G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError
+{% if sonar_search_javaopts %}
+# Same as previous property, but allows to not repeat all other settings like -Xmx
+sonar.search.javaOpts={{ sonar_search_javaopts }}
+{% endif %}
 {% if sonar_search_javaadditionalopts %}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 sonar.search.javaAdditionalOpts={{ sonar_search_javaadditionalopts }}

--- a/templates/sonar.properties
+++ b/templates/sonar.properties
@@ -249,6 +249,14 @@ sonar.web.javaAdditionalOpts={{ sonar_web_javaadditionalopts }}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 #sonar.ce.javaAdditionalOpts=
 
+{% if sonar_ce_javaopts %}
+sonar.ce.javaOpts={{ sonar_ce_javaopts }}
+{% endif %}
+{% if sonar_ce_javaadditionalopts %}
+# Same as previous property, but allows to not repeat all other settings like -Xmx
+sonar.ce.javaAdditionalOpts={{ sonar_ce_javaadditionalopts }}
+{% endif %}
+
 
 #--------------------------------------------------------------------------------------------------
 # ELASTICSEARCH
@@ -269,6 +277,9 @@ sonar.web.javaAdditionalOpts={{ sonar_web_javaadditionalopts }}
 # JVM options of Elasticsearch process
 #sonar.search.javaOpts=-Xms2G -Xmx2G -XX:+HeapDumpOnOutOfMemoryError
 
+{% if sonar_search_javaopts %}
+sonar.search.javaOpts={{ sonar_search_javaopts }}
+{% endif %}
 {% if sonar_search_javaadditionalopts %}
 # Same as previous property, but allows to not repeat all other settings like -Xmx
 sonar.search.javaAdditionalOpts={{ sonar_search_javaadditionalopts }}


### PR DESCRIPTION
### Changes to this role
**What works**
- Add tasks to configure datadog logging directories
- Add tasks to add datadog apm instrumentation to sonarqube
- This includes JVM metrics for the current Java heap. 

**What's sort of weird**
- The service name won't register for sonarqube's database (postgresql and elasticsearch) that're in the instance. I cannot change their name in the reporting.  
- Even though tracing is enabled, apm traces do not match up with the log.  

This role assumes the vanilla datadog-agent was already configured, if it hasn't been please do not run the tasks tagged `datadog`.

![Screen Shot 2019-11-07 at 4 06 56 PM](https://user-images.githubusercontent.com/2095881/68428104-77c08e00-0179-11ea-957b-c3f0f2150d62.png)
![Screen Shot 2019-11-07 at 4 08 24 PM](https://user-images.githubusercontent.com/2095881/68428105-77c08e00-0179-11ea-8361-a72999adb6cf.png)
