### PR TITLE
[SR-1268] Bring Postgres in-house

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ bbaassssiiee.sonar
 
 Sonar is a source-code quality tool.
 
+### Important!
+This role no longer has the postgres role (see meta/main.yml). You must provide your own for this role to work.
+
 Requirements
 ------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,4 +30,3 @@ dependencies:
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
   - { role: dockpack.base_java8 }
-  - { role: bbaassssiiee.base_postgres }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,3 +30,9 @@ dependencies:
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
   - { role: dockpack.base_java8 }
+
+  # Deprecated:
+  # - { role: bbaassssiiee.base_postgres }
+  # This galaxy role has a broken flow, i.e. the
+  #  `restart iptables` task is commented out which causes the play to break
+  #  You must provide your own postgres role, look in ansible repo, roles/postgres


### PR DESCRIPTION
Ticket: [SR-1268](https://renttherunway.jira.com/browse/SR-1268)

This role was formerly an ansible galaxy role called [bbaassssiiee/base_postgres](https://github.com/bbaassssiiee/base_postgres/). It is basically a direct "fork" of that role, brought to here, identical in all code except that

1. The molecule testing framework and other irrelevant code was taken out
2. The `restart iptables` task is uncommented now

I'd like to bring it in-house for 2 reasons:

- Right now it errors out when running on the new box because the current galaxy role we use (bbaassssiiee.base_postgres) has the `restart iptables` handler task commented out, but it's still called upon in the `notify` [here](https://github.com/bbaassssiiee/base_postgres/blob/c8b5d6fdcdbfbd98a76b373bc859c9ef4a23a2a7/tasks/config.yml#L124). This causes the following error msg:
```
16:26:12  TASK [bbaassssiiee.base_postgres : 
 fix "postgresql" in /etc/sysconfig/iptables file] ***
16:26:12  ERROR! The requested handler 'restart iptables' was
 not found in either the main handlers list nor in the 
 listening handlers list
```

- This lets us modify the role to suit our needs. If it were open-source and up-to-date, I'd make a public PR, but it seems to be archived in favor of `dockpack.base_postgres` anyway. 

### Other PRs
- https://github.com/RentTheRunway/ansible/pull/34 (merge this first, before this one)
