### PR TITLE
SR-1396: s/http/https

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ sonar_username: 'sonaruser'
 sonar_password: 'Terrible_Password_1234'
 
 sonarrunner_zipfile: 'sonar-runner-dist-2.4.zip'
-sonarrunner_url: 'http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip'
+sonarrunner_url: 'https://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip'
 
 
 sonar_version: 6.2


### PR DESCRIPTION
Ticket: [SR-1396](https://renttherunway.jira.com/browse/SR-1396)

## Description:
- Error has come up recently, where the URL now responds with `HTTP Error 501: HTTPS Required` for the download of the sonar-runner plugin. 
- s/http/https

