### PR TITLE
SR-1411: Connection timeout hotfix

### DIFF
--- a/tasks/memory_config.yml
+++ b/tasks/memory_config.yml
@@ -30,5 +30,5 @@
   wait_for_connection:
     connect_timeout: 20
     sleep: 5
-    delay: 5
+    delay: 120 # upping this to 2m, not sure why wait_for_connection passes when next task fails from UNREACHABLE host
     timeout: 300


### PR DESCRIPTION
Upping delay timeout on `wait_for_connection`

For some reason `wait_for_connection` passes, but the next task always fails from `UNREACHABLE` host error. Upping delay timeout until better understanding around the issue


```
16:19:47  TASK [sonar : Reboot to load memory changes] ***********************************

16:19:49  changed: [sonarqube01.m.dfw.rtrdc.net] => {"ansible_job_id": "778984766575.9113", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/778984766575.9113", "started": 1}
16:19:49  
16:19:49  TASK [sonar : Wait for the reboot to complete] *********************************

16:19:55  ok: [sonarqube01.m.dfw.rtrdc.net] => {"changed": false, "elapsed": 5}
16:19:55  
16:19:55  TASK [sonar : make sure postgresql packages are installed] *********************
16:19:55  [DEPRECATION WARNING]: Invoking "yum" only once while using a loop via 
16:19:55  squash_actions is deprecated. Instead of using a loop to supply multiple items 
16:19:55  and specifying `name: "{{item}}"`, please use `name: ['unzip', 'python-
16:19:55  psycopg2', 'python-psycopg2-doc']` and remove the loop. This feature will be 
16:19:55  removed in version 2.11. Deprecation warnings can be disabled by setting 
16:19:55  deprecation_warnings=False in ansible.cfg.
16:19:55  failed: [sonarqube01.m.dfw.rtrdc.net] (item=[u'unzip', u'python-psycopg2', u'python-psycopg2-doc']) => {"item": ["unzip", "python-psycopg2", "python-psycopg2-doc"], "msg": "Failed to connect to the host via ssh: ssh: connect to host sonarqube01.m.dfw.rtrdc.net port 22: Connection refused", "unreachable": true}
16:19:55  fatal: [sonarqube01.m.dfw.rtrdc.net]: UNREACHABLE! => {"changed": false, "msg": "All items completed", "results": [{"_ansible_ignore_errors": null, "_ansible_item_label": ["unzip", "python-psycopg2", "python-psycopg2-doc"], "_ansible_item_result": true, "item": ["unzip", "python-psycopg2", "python-psycopg2-doc"], "msg": "Failed to connect to the host via ssh: ssh: connect to host sonarqube01.m.dfw.rtrdc.net port 22: Connection refused", "unreachable": true}]}
16:19:55  
```