### PR TITLE
SR-1455: Minimize permissions for secrets file

### DIFF
--- a/tasks/sonar_config.yml
+++ b/tasks/sonar_config.yml
@@ -45,7 +45,7 @@
   template:
     src: ../templates/sonar-secret.txt
     dest: "{{ sonar_home }}/.sonar"
-    mode: 0644
+    mode: 0400
     owner: "{{ sonar_username }}"
     group: "{{ sonar_username }}"
 


### PR DESCRIPTION
[SR-1455: Re-stabilize the SQ playbook](https://renttherunway.jira.com/browse/SR-1455)

Fix permissions to resolve Okta error that occurs. If we don't do this, you'll get the following errors:
- A 500 when trying to login via Okta
```
"GET /api/users/identity_providers HTTP/1.0" 500 79 "https://sonarqube01.m.dfw.rtrdc.net/sessions/new"
```

And the following error in logs:
```
Fail to process request http://127.0.0.1:9000/api/users/identity_providers

java.lang.IllegalStateException: 
Fail to decrypt the property sonar.auth.saml.certificate.secured. 
Please check your secret key.

Caused by: java.lang.IllegalStateException: 
The property sonar.secretKeyPath does not link to a valid file: 
<$SONAR_HOME>/sonar/sonar-secret.txt
at org.sonar.api.config.AesCipher.loadSecretFileFromFile(AesCipher.java:103)
```