### PR TITLE
SR-1455: Fix permissions for the .sonar dir

### DIFF
--- a/tasks/sonar_config.yml
+++ b/tasks/sonar_config.yml
@@ -36,7 +36,7 @@
 - name: 'add directory for sonar-secret file'
   file:
     dest: "{{ sonar_home }}/.sonar"
-    mode: 0644
+    mode: 0500
     state: directory
     owner: "{{ sonar_username }}"
     group: "{{ sonar_username }}"


### PR DESCRIPTION
Part of [SR-1455: Re-stabilize the SQ playbook](https://renttherunway.jira.com/browse/SR-1455)

- This is actually the last fix needed to ensure `sonar-secret.txt` is accessible and usable by auth/Okta; it also needs the parent directory (`.sonar`) to be readable and executable. 